### PR TITLE
add STACK to heroku ruby.rb given new AWS path structure

### DIFF
--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -14,7 +14,7 @@ Encoding.default_external = Encoding::UTF_8 if defined?(Encoding)
 class LanguagePack::Base
   include LanguagePack::ShellHelpers
 
-  VENDOR_URL = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/cedar"
+  VENDOR_URL = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby"
 
   attr_reader :build_path, :cache
 

--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -14,7 +14,7 @@ Encoding.default_external = Encoding::UTF_8 if defined?(Encoding)
 class LanguagePack::Base
   include LanguagePack::ShellHelpers
 
-  VENDOR_URL = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby"
+  VENDOR_URL = "https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/cedar"
 
   attr_reader :build_path, :cache
 

--- a/lib/language_pack/rails4.rb
+++ b/lib/language_pack/rails4.rb
@@ -100,7 +100,7 @@ WARNING
           @cache.store default_assets_cache
         else
           log "assets_precompile", :status => "failure"
-          error "Precompiling assets failed."
+          error "Precompiling assets failed (Rails 4)."
         end
       end
     end
@@ -111,4 +111,27 @@ WARNING
       LanguagePack::Helpers::StaleFileCleaner.new(default_assets_cache).clean_over(ASSETS_CACHE_LIMIT)
     end
   end
+
+private
+
+  # setup the database url as an environment variable
+  def setup_database_url_env
+    instrument "rails4.setup_database_url_env" do
+      ENV["DATABASE_URL"] ||= begin
+        # need to use a dummy DATABASE_URL here, so rails can load the environment
+        scheme =
+          if bundler.has_gem?("pg") || bundler.has_gem?("jdbc-postgres")
+            "postgres"
+          elsif bundler.has_gem?("mysql")
+            "mysql"
+          elsif bundler.has_gem?("mysql2")
+            "mysql2"
+          elsif bundler.has_gem?("sqlite3") || bundler.has_gem?("sqlite3-ruby")
+            "sqlite3"
+          end
+        "#{scheme}://user:pass@127.0.0.1/dbname"
+      end
+    end
+  end
+
 end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -124,7 +124,7 @@ private
   def default_path
     "bin:#{bundler_binstubs_path}:/usr/local/bin:/usr/bin:/bin:/app/vendor/gsl-1/bin"
   end
-  
+
   def ld_path
     "/app/vendor/gsl-1/lib"
   end
@@ -258,7 +258,7 @@ ERROR
         Dir.chdir(build_ruby_path) do
           ruby_vm = "ruby"
           instrument "ruby.fetch_build_ruby" do
-            @fetchers[:buildpack].fetch_untar("#{ruby_version.version.sub(ruby_vm, "#{ruby_vm}-build")}.tgz")
+            @fetchers[:buildpack].fetch_untar("cedar/#{ruby_version.version.sub(ruby_vm, "#{ruby_vm}-build")}.tgz")
           end
         end
         error invalid_ruby_version_message unless $?.success?
@@ -694,7 +694,7 @@ params = CGI.parse(uri.query || "")
       end
     end
   end
-  
+
 	def bundler_cache
     "vendor/bundle"
   end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -22,6 +22,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   LEGACY_JVM_VERSION   = "openjdk1.7.0_25"
   DEFAULT_RUBY_VERSION = "ruby-2.0.0"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"
+  STACK                = "cedar"
 
   # detects if this is a valid Ruby app
   # @return [Boolean] true if it's a Ruby app
@@ -258,7 +259,7 @@ ERROR
         Dir.chdir(build_ruby_path) do
           ruby_vm = "ruby"
           instrument "ruby.fetch_build_ruby" do
-            @fetchers[:buildpack].fetch_untar("cedar/#{ruby_version.version.sub(ruby_vm, "#{ruby_vm}-build")}.tgz")
+            @fetchers[:buildpack].fetch_untar("#{STACK}/#{ruby_version.version.sub(ruby_vm, "#{ruby_vm}-build")}.tgz")
           end
         end
         error invalid_ruby_version_message unless $?.success?
@@ -268,7 +269,7 @@ ERROR
       Dir.chdir(slug_vendor_ruby) do
         instrument "ruby.fetch_ruby" do
           if ruby_version.rbx?
-            file     = "#{ruby_version.version}.tar.bz2"
+            file     = "#{STACK}/#{ruby_version.version}.tar.bz2"
             sha_file = "#{file}.sha1"
             @fetchers[:rbx].fetch(file)
             @fetchers[:rbx].fetch(sha_file)
@@ -288,7 +289,7 @@ ERROR_MSG
             FileUtils.rm(file)
             FileUtils.rm(sha_file)
           else
-            @fetchers[:buildpack].fetch_untar("#{ruby_version.version}.tgz")
+            @fetchers[:buildpack].fetch_untar("#{STACK}/#{ruby_version.version}.tgz")
           end
         end
       end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -106,8 +106,7 @@ class LanguagePack::Ruby < LanguagePack::Base
       setup_profiled
       allow_git do
         install_gsl
-        run("cp -R vendor/gsl-1 /app/vendor/gsl")
-        run("cp -R vendor/gsl-1 /app/vendor/gsl-1")
+        run("cp -R /vendor/gsl-1 /app/vendor/gsl-1")
         install_language_pack_gems
         build_bundler
         create_database_yml

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -106,7 +106,8 @@ class LanguagePack::Ruby < LanguagePack::Base
       setup_profiled
       allow_git do
         install_gsl
-        run("cp -R /vendor/gsl-1 /app/vendor/gsl-1")
+        # ensure ./app/vendor dir exists
+        run("cp -R ./vendor/gsl-1 ./app/vendor/gsl-1")
         install_language_pack_gems
         build_bundler
         create_database_yml

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -13,7 +13,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.4"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "1.5.2"
+  BUNDLER_VERSION      = "1.9.7"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   NODE_VERSION         = "0.4.7"
   NODE_JS_BINARY_PATH  = "node-#{NODE_VERSION}"

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -106,7 +106,7 @@ class LanguagePack::Ruby < LanguagePack::Base
       setup_profiled
       allow_git do
         install_gsl
-        # ensure ./app/vendor dir exists
+        run("mkdir ./app/vendor")
         run("cp -R ./vendor/gsl-1 ./app/vendor/gsl-1")
         install_language_pack_gems
         build_bundler


### PR DESCRIPTION
It appear that the directory structure has changed on AWS where heroku is storing their buildpacks. See https://github.com/heroku/heroku-buildpack-ruby/issues/304 for more info. Small change in ruby.rb to enable setting and using STACK to match new directory structure.
